### PR TITLE
Build multi-platform (amd64/arm64) container images

### DIFF
--- a/.github/workflows/manually-build-and-publish-container-image.yml
+++ b/.github/workflows/manually-build-and-publish-container-image.yml
@@ -8,7 +8,14 @@ permissions:
 
 jobs:
   build-and-publish-container-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4
@@ -26,7 +33,24 @@ jobs:
         run: >-
           ./gradlew bootBuildImage
           -Pversion=$( git describe --tags )
-          -PcontainerImageTag=$( git describe --tags )
+          -PcontainerImageTag=$( git describe --tags )-${{ matrix.arch }}
           -PpublishImage=true
           -PregistryUsername=${{ github.actor }}
           -PregistryPassword=${{ secrets.GITHUB_TOKEN }}
+
+  publish-multiplatform-manifest:
+    needs: build-and-publish-container-image
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Log in to GitHub Packages container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Create and publish multi-platform manifest
+        run: >-
+          docker buildx imagetools create
+          -t ghcr.io/neuland/kafka-bridge:$( git describe --tags )
+          ghcr.io/neuland/kafka-bridge:$( git describe --tags )-amd64
+          ghcr.io/neuland/kafka-bridge:$( git describe --tags )-arm64

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -7,7 +7,14 @@ on:
 
 jobs:
   build-and-publish-container-image:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            arch: amd64
+          - os: ubuntu-24.04-arm
+            arch: arm64
+    runs-on: ${{ matrix.os }}
 
     permissions:
       packages: write
@@ -28,15 +35,32 @@ jobs:
         run: >-
           ./gradlew bootBuildImage
           -Pversion=$( git describe --tags --exact-match --abbrev=0 )
-          -PcontainerImageTag=$( git describe --tags --exact-match --abbrev=0 )
+          -PcontainerImageTag=$( git describe --tags --exact-match --abbrev=0 )-${{ matrix.arch }}
           -PpublishImage=true
           -PregistryUsername=${{ github.actor }}
           -PregistryPassword=${{ secrets.GITHUB_TOKEN }}
-      - name: Build and publish container image as latest
+
+  publish-multiplatform-manifest:
+    needs: build-and-publish-container-image
+    runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Log in to GitHub Packages container registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      - name: Create and publish multi-platform manifest for release tag
         run: >-
-          ./gradlew bootBuildImage
-          -Pversion=$( git describe --tags --exact-match --abbrev=0 )
-          -PcontainerImageTag=latest
-          -PpublishImage=true
-          -PregistryUsername=${{ github.actor }}
-          -PregistryPassword=${{ secrets.GITHUB_TOKEN }}
+          docker buildx imagetools create
+          -t ghcr.io/neuland/kafka-bridge:$( git describe --tags --exact-match --abbrev=0 )
+          ghcr.io/neuland/kafka-bridge:$( git describe --tags --exact-match --abbrev=0 )-amd64
+          ghcr.io/neuland/kafka-bridge:$( git describe --tags --exact-match --abbrev=0 )-arm64
+      - name: Tag release manifest as latest
+        run: >-
+          docker buildx imagetools create
+          -t ghcr.io/neuland/kafka-bridge:latest
+          ghcr.io/neuland/kafka-bridge:$( git describe --tags --exact-match --abbrev=0 )


### PR DESCRIPTION
Add matrix build across amd64 and arm64 runners, then merge into a single multi-arch manifest via docker buildx imagetools create.